### PR TITLE
Change Claim from Name to Email

### DIFF
--- a/src/idunno.CookieSharing.Core/Controllers/HomeController.cs
+++ b/src/idunno.CookieSharing.Core/Controllers/HomeController.cs
@@ -26,7 +26,7 @@ namespace idunno.CookieSharing.Core.Controllers
                 var identity = new ClaimsIdentity(
                     new List<Claim>
                     {
-                        new Claim(ClaimTypes.Name, model.Email, ClaimValueTypes.String, Issuer)
+                        new Claim(ClaimTypes.Email, model.Email, ClaimValueTypes.String, Issuer)
                     },
                     ClaimTypes.Email,
                     ClaimTypes.Role,


### PR DESCRIPTION
There was a mismatch such that this couldn't have worked unless you logged in to Core first. This caused a YSOD in Full. The claims need to be symmetrical.
